### PR TITLE
w/d/l -> VOF (not VLF) in Swedish

### DIFF
--- a/sv.json
+++ b/sv.json
@@ -85,7 +85,7 @@
     "challenge_card": {
       "win": "Vinst",
       "loss": "Förlust",
-      "draw": "Lika",
+      "draw": "Oavgjort",
       "pro": "PROFFS"
     },
     "chat": {
@@ -585,7 +585,7 @@
   "challenge": {
     "win": "Vinst",
     "loss": "Förlust",
-    "draw": "Lika",
+    "draw": "Oavgjort",
     "vs": "MOT",
     "tot": "TOT",
     "avg": "MDL",

--- a/sv.json
+++ b/sv.json
@@ -592,7 +592,7 @@
     "challenges": "Utmaningar",
     "ranked": "Rankad",
     "friendly": "Vänskaplig",
-    "wdl": "V/L/F",
+    "wdl": "V/O/F",
     "win_percent": "Vinst %",
     "boards": "Brickor",
     "with": "MED",


### PR DESCRIPTION
I was confused when I saw V/L/F in Swedish, thinking L also sounded like "Loss". I now realise it was for Lika, but probably O for Oavgjort is better (in ranked stats).
I now also realise we need to change the long text, which could be too long for ui in some places?
So not sure this is a good change