### PR TITLE
[codex] Add practice disabled reason locale strings

### DIFF
--- a/app/en.json
+++ b/app/en.json
@@ -1210,6 +1210,8 @@
     "start_short": "Start",
     "start_practice_session": "Start practice session",
     "scenarios_requires_heart": "You need a Heart subscription to use scenarios.",
+    "partner_loading_info": "Loading selected partner...",
+    "boards_range_info": "Select number of boards between 1 and 24.",
     "show_session_headline": "Name session",
     "headline_too_long": "Too long name, max {{max}} characters",
     "how_to": {

--- a/app/es.json
+++ b/app/es.json
@@ -1213,6 +1213,8 @@
     "start_short": "Empezar",
     "start_practice_session": "Iniciar sesión de práctica",
     "scenarios_requires_heart": "Necesitas una suscripción Heart para usar escenarios.",
+    "partner_loading_info": "Cargando el compañero seleccionado...",
+    "boards_range_info": "Selecciona un número de manos entre 1 y 24.",
     "show_session_headline": "Poner nombre a la sesión",
     "headline_too_long": "Nombre demasiado largo, máximo {{max}} caracteres",
     "how_to": {

--- a/app/fr.json
+++ b/app/fr.json
@@ -1209,6 +1209,8 @@
     "start_short": "Démarrer",
     "start_practice_session": "Démarrer une séance d’entraînement",
     "scenarios_requires_heart": "Vous avez besoin d’un abonnement Coeur pour utiliser les scénarios.",
+    "partner_loading_info": "Chargement du partenaire sélectionné...",
+    "boards_range_info": "Sélectionnez un nombre de donnes entre 1 et 24.",
     "show_session_headline": "Nomme la session",
     "headline_too_long": "Nom trop long, {{max}} caractères maximum",
     "how_to": {

--- a/app/pl.json
+++ b/app/pl.json
@@ -1209,6 +1209,8 @@
     "start_short": "Start",
     "start_practice_session": "Rozpocznij sesję treningową",
     "scenarios_requires_heart": "Potrzebujesz subskrypcji Kier, aby korzystać ze scenariuszy.",
+    "partner_loading_info": "Wczytywanie wybranego partnera...",
+    "boards_range_info": "Wybierz liczbę rozdań od 1 do 24.",
     "show_session_headline": "Nazwij sesję",
     "headline_too_long": "Nazwa za długa, maksymalnie {{max}} znaków",
     "how_to": {

--- a/app/sv.json
+++ b/app/sv.json
@@ -1209,6 +1209,8 @@
     "start_short": "Starta",
     "start_practice_session": "Starta träningssession",
     "scenarios_requires_heart": "Scenarion kräver en hjärterprenumeration.",
+    "partner_loading_info": "Läser in vald partner...",
+    "boards_range_info": "Välj antal brickor mellan 1 och 24.",
     "show_session_headline": "Namnge session",
     "headline_too_long": "För lång namn, {{max}} tecken",
     "how_to": {

--- a/app/zh.json
+++ b/app/zh.json
@@ -1213,6 +1213,8 @@
     "start_short": "开始",
     "start_practice_session": "开始练习",
     "scenarios_requires_heart": "你需要红桃订阅才能使用场景。",
+    "partner_loading_info": "正在加载所选搭档…",
+    "boards_range_info": "请选择 1 到 24 副牌。",
     "show_session_headline": "为牌局命名",
     "headline_too_long": "名称太长，最多 {{max}} 个字符",
     "how_to": {

--- a/en.json
+++ b/en.json
@@ -1134,6 +1134,8 @@
     "start_short": "Start",
     "start_practice_session": "Start practice session",
     "scenarios_requires_heart": "You need a Heart subscription to use scenarios.",
+    "partner_loading_info": "Loading selected partner...",
+    "boards_range_info": "Select number of boards between 1 and 24.",
     "show_session_headline": "Name session",
     "headline_too_long": "Too long name, max {{max}} characters",
     "how_to": {

--- a/es.json
+++ b/es.json
@@ -1137,6 +1137,8 @@
     "start_short": "Empezar",
     "start_practice_session": "Iniciar sesión de práctica",
     "scenarios_requires_heart": "Necesitas una suscripción Heart para usar escenarios.",
+    "partner_loading_info": "Cargando el compañero seleccionado...",
+    "boards_range_info": "Selecciona un número de manos entre 1 y 24.",
     "show_session_headline": "Poner nombre a la sesión",
     "headline_too_long": "Nombre demasiado largo, máximo {{max}} caracteres",
     "how_to": {

--- a/fr.json
+++ b/fr.json
@@ -1133,6 +1133,8 @@
     "start_short": "Démarrer",
     "start_practice_session": "Démarrer une séance d’entraînement",
     "scenarios_requires_heart": "Vous avez besoin d’un abonnement Coeur pour utiliser les scénarios.",
+    "partner_loading_info": "Chargement du partenaire sélectionné...",
+    "boards_range_info": "Sélectionnez un nombre de donnes entre 1 et 24.",
     "show_session_headline": "Nomme la session",
     "headline_too_long": "Nom trop long, {{max}} caractères maximum",
     "how_to": {

--- a/pl.json
+++ b/pl.json
@@ -1133,6 +1133,8 @@
     "start_short": "Start",
     "start_practice_session": "Rozpocznij sesję treningową",
     "scenarios_requires_heart": "Potrzebujesz subskrypcji Kier, aby korzystać ze scenariuszy.",
+    "partner_loading_info": "Wczytywanie wybranego partnera...",
+    "boards_range_info": "Wybierz liczbę rozdań od 1 do 24.",
     "show_session_headline": "Nazwij sesję",
     "headline_too_long": "Nazwa za długa, maksymalnie {{max}} znaków",
     "how_to": {

--- a/sv.json
+++ b/sv.json
@@ -1133,6 +1133,8 @@
     "start_short": "Starta",
     "start_practice_session": "Starta träningssession",
     "scenarios_requires_heart": "Scenarion kräver en hjärterprenumeration.",
+    "partner_loading_info": "Läser in vald partner...",
+    "boards_range_info": "Välj antal brickor mellan 1 och 24.",
     "show_session_headline": "Namnge session",
     "headline_too_long": "För lång namn, {{max}} tecken",
     "how_to": {

--- a/zh.json
+++ b/zh.json
@@ -1138,6 +1138,8 @@
     "start_short": "开始",
     "start_practice_session": "开始练习",
     "scenarios_requires_heart": "你需要红桃订阅才能使用场景。",
+    "partner_loading_info": "正在加载所选搭档…",
+    "boards_range_info": "请选择 1 到 24 副牌。",
     "show_session_headline": "为牌局命名",
     "headline_too_long": "名称太长，最多 {{max}} 个字符",
     "how_to": {


### PR DESCRIPTION
## What changed
- add the missing practice-session disabled reason strings for partner loading and invalid board count
- keep app and root locale files in sync for en, sv, es, fr, pl, and zh

## Why
- the parent CUE-182 change now surfaces a concrete reason below the disabled start button
- these two strings were the only missing locale entries for that flow

## Validation
- JSON parse check for all updated locale files
